### PR TITLE
Patch to fix #63: allow use of a wrapped endpoints.method

### DIFF
--- a/endpoints_proto_datastore/ndb/model.py
+++ b/endpoints_proto_datastore/ndb/model.py
@@ -1270,7 +1270,7 @@ class EndpointsModel(ndb.Model):
     if response_message is None:
       kwargs[RESPONSE_MESSAGE] = cls.ProtoModel(fields=response_fields)
 
-    endpoints_method_decorator = kwargs.pop("_method_decorator", endpoints.method)
+    endpoints_method_decorator = kwargs.pop('_method_decorator', endpoints.method)
     apiserving_method_decorator = endpoints_method_decorator(**kwargs)
 
     def RequestToEntityDecorator(api_method):
@@ -1441,7 +1441,7 @@ class EndpointsModel(ndb.Model):
                         'Received %s.' % (kwargs[HTTP_METHOD],))
     kwargs[HTTP_METHOD] = QUERY_HTTP_METHOD
 
-    endpoints_method_decorator = kwargs.pop("_method_decorator", endpoints.method)
+    endpoints_method_decorator = kwargs.pop('_method_decorator', endpoints.method)
     apiserving_method_decorator = endpoints_method_decorator(**kwargs)
 
     def RequestToQueryDecorator(api_method):


### PR DESCRIPTION
Allow use of a wrapped endpoints.method in EndpointsModel.method and EndpointsModel.query_method.

I'm setting the default namespace using namespace_manager based on the logged in user. To prevent forgetting setting of the namespace I put it in a wrapper, so that it gets done on each request.
This is similar to leveraging appengine_config.py:namespace_manager_default_namespace_for_request. The reason for not using that is because endpoints.get_current_user() doesn't work outside of an endpoints.method decorated function.

This patch adds _method_decorator as an argument to EndpointsModel.method and EndpointsModel.query_method.  The default is to use endpoints.method as before.
