### PR TITLE
Adding "multi_put" example.

### DIFF
--- a/examples/matching_queries_to_indexes/app.yaml
+++ b/examples/matching_queries_to_indexes/app.yaml
@@ -15,4 +15,3 @@ libraries:
   version: "2.6"
 - name: endpoints
   version: 1.0
-

--- a/examples/multi_put/app.yaml
+++ b/examples/multi_put/app.yaml
@@ -1,0 +1,1 @@
+../basic/app.yaml

--- a/examples/multi_put/main.py
+++ b/examples/multi_put/main.py
@@ -1,0 +1,30 @@
+import endpoints
+
+from google.appengine.ext import ndb
+from protorpc import remote
+
+from endpoints_proto_datastore.ndb import EndpointsModel
+
+
+class MyModel(EndpointsModel):
+  attr1 = ndb.StringProperty()
+  attr2 = ndb.StringProperty()
+  created = ndb.DateTimeProperty(auto_now_add=True)
+
+
+@endpoints.api(name='myapi', version='v1', description='My Little API')
+class MyApi(remote.Service):
+
+  @MyModel.method(request_message=MyModel.ProtoCollection(),
+                  response_message=MyModel.ProtoCollection(),
+                  user_required=True,
+                  path='mymodel_multi',
+                  name='mymodel.insert_multi')
+  def MyModelMultiInsert(self, items):
+    entities = [MyModel.FromMessage(item_msg) for item_msg in items.items]
+    ndb.put_multi(entities)
+    items.items = [entity.ToMessage() for entity in entities]
+    return items
+
+
+application = endpoints.api_server([MyApi], restricted=False)

--- a/examples/paging/app.yaml
+++ b/examples/paging/app.yaml
@@ -15,4 +15,3 @@ libraries:
   version: "2.6"
 - name: endpoints
   version: 1.0
-


### PR DESCRIPTION
This shows how to use endpoints-proto-datastore to
insert multiple items at once as a collection.
