### PR TITLE
Fixing how PickleProperty's are surface in the API.

### DIFF
--- a/endpoints_proto_datastore/ndb/model.py
+++ b/endpoints_proto_datastore/ndb/model.py
@@ -14,7 +14,6 @@ try:
   import json
 except ImportError:
   import simplejson as json
-import pickle
 import re
 
 import endpoints
@@ -100,8 +99,6 @@ def ToValue(prop, value):
     return prop.ToValue(value)
   elif isinstance(prop, ndb.JsonProperty):
     return json.dumps(value)
-  elif isinstance(prop, ndb.PickleProperty):
-    return pickle.dumps(value)
   elif isinstance(prop, ndb.UserProperty):
     return utils.UserMessageFromUser(value)
   elif isinstance(prop, ndb.GeoPtProperty):
@@ -148,8 +145,6 @@ def FromValue(prop, value):
     return prop.FromValue(value)
   elif isinstance(prop, ndb.JsonProperty):
     return json.loads(value)
-  elif isinstance(prop, ndb.PickleProperty):
-    return pickle.loads(value)
   elif isinstance(prop, ndb.UserProperty):
     return utils.UserMessageToUser(value)
   elif isinstance(prop, ndb.GeoPtProperty):

--- a/endpoints_proto_datastore/ndb/utils.py
+++ b/endpoints_proto_datastore/ndb/utils.py
@@ -60,7 +60,7 @@ NDB_PROPERTY_TO_PROTO = {
     ndb.ModelKey: RaiseNotImplementedMethod(
         ndb.ModelKey,
         explanation=MODEL_KEY_EXPLANATION),
-    ndb.PickleProperty: messages.BytesField,
+    ndb.PickleProperty: messages.StringField,
     ndb.Property: RaiseNotImplementedMethod(ndb.Property),
     ndb.StringProperty: messages.StringField,
     ndb.TextProperty: messages.StringField,  # No concept of compressed here


### PR DESCRIPTION
Uses a string and leaves pickling/unpickling to the
property itself rather than forcing the user to do the
same.

Fixes #114.

@kdeus PTAL
